### PR TITLE
Updates CRD example

### DIFF
--- a/apps/cr/visitor-java.yml
+++ b/apps/cr/visitor-java.yml
@@ -1,7 +1,8 @@
-apiVersion: com.redhat.operators/v1
+apiVersion: app.operators.redhat.com/v1
 kind: Visitor
 metadata:
   name: visitorsapp-sample
 spec:
   size: 1
   title: "My First Operator in Quarkus!"
+  

--- a/documentation/modules/ROOT/pages/05-java.adoc
+++ b/documentation/modules/ROOT/pages/05-java.adoc
@@ -180,8 +180,8 @@ You can now apply a custom resource
 [.console-input]
 [source,yaml,subs="+macros,+attributes"]
 ----
-apiVersion: app.redhat.com/v1
-kind: VisitorsApp
+apiVersion: app.operators.redhat.com/v1
+kind: Visitor
 metadata:
   name: visitorsapp-sample
 spec:
@@ -192,7 +192,7 @@ spec:
 [.console-input]
 [source,bash,subs="+macros,+attributes"]
 ----
-kubectl apply -f $TUTORIAL_HOME/apps/cr/visitorsapp-java.yaml
+kubectl apply -f $TUTORIAL_HOME/apps/cr/visitor-java.yml
 ----
 
 Check the pods getting created :


### PR DESCRIPTION
By following the guide, the generated Visitor class is:

``` java
@Version("v1")
@Group("app.operators.redhat.com")
@Kind("Visitor")
@Plural("visitors")
```

And the generated visitors.app.operators.redhat.com-v1.yml:

``` yml
apiVersion: apiextensions.k8s.io/v1
kind: CustomResourceDefinition
metadata:
  name: visitors.app.operators.redhat.com
spec:
  group: app.operators.redhat.com
  names:
    kind: Visitor
    plural: visitors
    singular: visitor
...
```

This PR updates `apiVersion` and `kind` of the example CR accordingly. 
Also updates filename on the tutorial text.